### PR TITLE
Revert "Improve output and handling of emojis"

### DIFF
--- a/moji.js
+++ b/moji.js
@@ -25,24 +25,11 @@ app.post("/decode", (req, res) => {
     return;
   }
 
-  // Splitting the emoji into its components if it contains a ZWJ
-  const components = emoji.includes("\u200D") ? emoji.split("\u200D") : [emoji];
-
-  // Retrieving the information for each component of the emoji
-  const info = components.map((component) => {
-    let name = EmojiDictionary.getName(component);
-    name = name === "null" || !name ? "(unknown)" : name;
-    const codepoint = `U+${emojiUnicode(component).toUpperCase()}`;
-
-    // Debug logging
-    console.log(
-      `Component: ${component}, Name: ${name}, Codepoint: ${codepoint}`,
-    );
-
-    return { name, codepoint };
-  });
-
-  res.json(info);
+  // Looking up emoji name and handling null/undefined results, generate codepoint
+  let emojiName = EmojiDictionary.getName(emoji);
+  emojiName = emojiName === "null" || !emojiName ? "(unknown)" : emojiName;
+  const codepoint = `U+${emojiUnicode(emoji).toUpperCase()}`;
+  res.json({ emojiName: emojiName, emojiCodepoint: codepoint });
 });
 app.get("/:emoji", (req, res) => {
   const emoji = decodeURIComponent(req.params.emoji);
@@ -51,24 +38,11 @@ app.get("/:emoji", (req, res) => {
     return;
   }
 
-  // Splitting the emoji into its components if it contains a ZWJ
-  const components = emoji.includes("\u200D") ? emoji.split("\u200D") : [emoji];
-
-  // Retrieving the information for each component of the emoji
-  const info = components.map((component) => {
-    let name = EmojiDictionary.getName(component);
-    name = name === "null" || !name ? "(unknown)" : name;
-    const codepoint = `U+${emojiUnicode(component).toUpperCase()}`;
-
-    // Debug logging
-    console.log(
-      `Component: ${component}, Name: ${name}, Codepoint: ${codepoint}`,
-    );
-
-    return { name, codepoint };
-  });
-
-  res.json(info);
+  // Looking up emoji name and handling null/undefined results, generate codepoint
+  let emojiName = EmojiDictionary.getName(emoji);
+  emojiName = emojiName === "null" || !emojiName ? "(unknown)" : emojiName;
+  const codepoint = `U+${emojiUnicode(emoji).toUpperCase()}`;
+  res.json({ emojiName: emojiName, emojiCodepoint: codepoint });
 });
 
 // Exporting the Express app and server instances for testing

--- a/test/moji.test.js
+++ b/test/moji.test.js
@@ -1,63 +1,46 @@
-const request = require("supertest");
-const chai = require("chai");
-const { app, server } = require("../moji");
-const { after, describe, it } = require("mocha");
+const request = require('supertest');
+const chai = require('chai');
+const { app, server } = require('../moji');
+const { after, describe, it } = require('mocha');
 const expect = chai.expect;
 
-describe("Moji the Decoder", () => {
+describe('Moji the Decoder', () => {
   after(() => {
     server.close();
   });
 
-  it("Server should be running", async () => {
-    const res = await request(app).get("/");
+  it('Server should be running', async () => {
+    const res = await request(app).get('/');
     expect(res.statusCode).to.equal(200);
   });
 
-  it("POST /decode should return name and codepoint for a known emoji", async () => {
-    const res = await request(app).post("/decode").send({ emoji: "😀" });
+  it('POST /decode should return name and codepoint for a known emoji', async () => {
+    const res = await request(app)
+      .post('/decode')
+      .send({ emoji: '😀' });
 
     expect(res.statusCode).to.equal(200);
-    expect(res.body).to.have.property("name", "grinning");
-    expect(res.body).to.have.property("codepoint", "U+1F600");
+    expect(res.body).to.have.property('name', 'grinning');
+    expect(res.body).to.have.property('codepoint', 'U+1F600');
   });
 
-  it("POST /decode should correctly split ZWJ characters and retrieve their information", async () => {
-    const res = await request(app).post("/decode").send({ emoji: "👁️‍🗨️" });
+  it('POST /decode should return (unknown) and hexcode for an unknown emoji', async () => {
+    const res = await request(app)
+      .post('/decode')
+      .send({ emoji: '🧑‍🚀' });
 
     expect(res.statusCode).to.equal(200);
-    expect(res.body).to.have.lengthOf(2);
-    expect(res.body[0]).to.have.property("name", "eye");
-    expect(res.body[0]).to.have.property("codepoint", "U+1F441 U+FE0F");
-    expect(res.body[1]).to.have.property("name", "left speech bubble");
-    expect(res.body[1]).to.have.property("codepoint", "U+1F5E8 U+FE0F");
+    expect(res.body).to.have.property('name', '(unknown)');
+    expect(res.body).to.have.property('codepoint', 'U+1F9D1 200D 1F680');
   });
 
-  it("POST /decode should return the correct information for each component of the emoji", async () => {
-    const res = await request(app).post("/decode").send({ emoji: "👨‍👩‍👧‍👦" });
+  it('POST /decode should return an error message if no emoji is sent', async () => {
+    const res = await request(app)
+      .post('/decode')
+      .send({ emoji: '' });
 
     expect(res.statusCode).to.equal(200);
-    expect(res.body).to.have.lengthOf(4);
-    expect(res.body[0]).to.have.property("name", "man");
-    expect(res.body[0]).to.have.property("codepoint", "U+1F468");
-    expect(res.body[1]).to.have.property("name", "woman");
-    expect(res.body[1]).to.have.property("codepoint", "U+1F469");
-    expect(res.body[2]).to.have.property("name", "girl");
-    expect(res.body[2]).to.have.property("codepoint", "U+1F467");
-    expect(res.body[3]).to.have.property("name", "boy");
-    expect(res.body[3]).to.have.property("codepoint", "U+1F466");
-  });
-  it("POST /decode should return (unknown) and hexcode for an unknown emoji", async () => {
-    const res = await request(app).post("/decode").send({ emoji: "🧑‍🚀" });
-
-    expect(res.statusCode).to.equal(200);
-    expect(res.body).to.have.property("name", "(unknown)");
-    expect(res.body).to.have.property("codepoint", "U+1F9D1 200D 1F680");
-  });
-  it("POST /decode should return an error message if no emoji is sent", async () => {
-    const res = await request(app).post("/decode").send({ emoji: "" });
-
-    expect(res.statusCode).to.equal(200);
-    expect(res.body).to.have.property("error", "No emoji provided");
+    expect(res.body).to.have.property('error', 'No emoji provided');
   });
 });
+


### PR DESCRIPTION
Reverts mikal-k/moji-the-decoder#18

$  node moji.js 
node:events:492
      throw er; // Unhandled 'error' event
      ^

Error: listen EADDRINUSE: address already in use :::2950
    at Server.setupListenHandle [as _listen2] (node:net:1751:16)
    at listenInCluster (node:net:1799:12)
    at Server.listen (node:net:1887:7)
    at Function.listen (/home/mikal/git/moji-the-decoder/node_modules/express/lib/application.js:635:24)
    at Object.<anonymous> (/home/mikal/git/moji-the-decoder/moji.js:16:20)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
Emitted 'error' event on Server instance at:
    at emitErrorNT (node:net:1778:8)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  code: 'EADDRINUSE',
  errno: -98,
  syscall: 'listen',
  address: '::',
  port: 2950
}

Node.js v18.17.1
